### PR TITLE
Transform Stefan reviewer to comment-triggered with inline comments

### DIFF
--- a/.github/workflows/claude-reviewer.yml
+++ b/.github/workflows/claude-reviewer.yml
@@ -1,14 +1,16 @@
 name: Claude Auto Review with Tracking
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@claude stefan-review') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+      issues: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -21,13 +23,21 @@ jobs:
           track_progress: true # ✨ Enables tracking comments
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            COMMENT AUTHOR: ${{ github.event.comment.user.login }}
+            COMMENT ID: ${{ github.event.comment.id }}
+            COMMENT BODY:
+            ---
+            ${{ github.event.comment.body }}
+            ---
 
             Please review this pull request using the stefan-reviewer subagent.
 
             Provide detailed feedback using inline comments for specific issues.
+            When posting inline comments, use the tool "create_inline_comment" with parameters:
+            - path, body, line, startLine, side, commit_id
+            Anchor comments to the PR head commit and use side="RIGHT".
 
           claude_args: |
-            --allowedTools
-            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr
-            comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
Transforms the Stefan reviewer from auto-triggering on all PR events to comment-triggered activation, and adds inline commenting capabilities for targeted code feedback.

## Changes Made

### GitHub Workflow Updates
- **Trigger Change**: From `pull_request: [opened, synchronize, ready_for_review, reopened]` to `issue_comment: [created]`
- **Conditional Activation**: Only runs when comment is on a PR and contains `@claude stefan-review`
- **Enhanced Context**: Passes PR NUMBER, COMMENT AUTHOR, COMMENT ID, and full COMMENT BODY to subagent
- **Updated Permissions**: Added `issues: read` for comment metadata access
- **Correct Tool Reference**: Uses `"create_inline_comment"` tool name

### Stefan Reviewer Subagent Enhancements
- **Comment Context Processing**: New step 0 for parsing trigger phrase and scope hints
- **Dual Output Architecture**: Maintains comprehensive markdown review while adding targeted inline comments
- **Inline Comment Integration**: Detailed guidelines for using `create_inline_comment` tool with proper parameters
- **Smart Safeguards**: Only creates inline comments when line mapping is confident, graceful fallbacks
- **Enhanced Command Patterns**: Updated with PR-specific commands and inline comment examples

## Benefits
- **Reduced Noise**: Reviews only run on explicit request via comments
- **Improved Precision**: Line-specific feedback via inline comments for Critical/Warning issues
- **Better Context**: Automatic PR discovery and scope parsing from comment triggers
- **Dual Documentation**: Both portable markdown reviews and actionable inline feedback

## Test Plan
- [ ] Create test PR with code changes
- [ ] Comment `@claude stefan-review` on the PR
- [ ] Verify workflow triggers only on comment (not PR sync events)
- [ ] Confirm both markdown review and inline comments are generated
- [ ] Test scope hints in comments (e.g., "files: src/", "only critical")

## Breaking Changes
The workflow no longer runs automatically on PR updates - it requires explicit `@claude stefan-review` comment to trigger.